### PR TITLE
created_privacy_policy

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,5 @@
 class StaticPagesController < ApplicationController
   def top; end
   def about_orceanize; end
+  def privacy_policy; end
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,6 @@
 <footer class="h-16 bg-blue-900 mt-auto">
   <div>
     <%= link_to 'Orceanizeについて', about_orceanize_path %>
+    <%= link_to 'プライバシーポリシー', privacy_policy_path %>
   </div>
 </footer>

--- a/app/views/static_pages/about_orceanize.html.erb
+++ b/app/views/static_pages/about_orceanize.html.erb
@@ -5,7 +5,7 @@
 
   <div class='mt-4 mb-3 container mx-auto px-8 '>
     <div class='border-solid border-2 bg-slate-100 p-2'>
-      <p class='text-lg'> 2016(平成28) 年1月に世界経済フォーラム (ダボス会議) が発表した報告書1)によると、<br>世界のプラスチック生産量が 1964〜2014 年の 50 年間で 20 倍以上に急増し、今後 20 年間でさらに倍増する見込みであること、毎年少なくとも 800 万 ton のプラスチックが海洋に流出し、BAU (business-as-usual) シナリオでは2050 年までには海洋中のプラスチック量が (重量ベースで) 魚の量を上回ると予想されており、国際的な関心が非常に高まっている</p>
+      <p class='text-lg text-center'> 2016(平成28) 年1月に世界経済フォーラム (ダボス会議) が発表した報告書1)によると、<br>世界のプラスチック生産量が 1964〜2014 年の 50 年間で 20 倍以上に急増し、今後 20 年間でさらに倍増する見込みであること、毎年少なくとも 800 万 ton のプラスチックが海洋に流出し、BAU (business-as-usual) シナリオでは2050 年までには海洋中のプラスチック量が (重量ベースで) 魚の量を上回ると予想されており、国際的な関心が非常に高まっている</p>
     </div>
     <br>
     <div class='text-right text-gray-400 text-xs'>
@@ -15,8 +15,8 @@
     <br>
 
 
-    <div>
-      <h1 class='text-center  text-3xl mb-5'>What is Orceanize?</h1>
+    <div class='text-center'>
+      <h1 class='text-3xl mb-5'>What is Orceanize?</h1>
       <p>Orceanizeは作成した海ごみアートを投稿し、世界中の海を愛する人とシェアすることができるプラットフォームです。</p>
       <p>OCEAN(海) と ORGANIZE(構成、整える)を合わせて、海を綺麗な状態にみんなで協力して整えていこうという意味を込めて名付けました。 </p>
       <br>

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,0 +1,65 @@
+
+<div class='mt-4 mb-3 container mx-auto px-14'>
+  <h1 class='border-t-4 border-b-4 border-blue-400 text-xl p-1'>プライバシーポリシー</h1>
+  <p class='mt-5'>Orceanize（以下、「当方」といいます。）は、本ウェブサイト上で提供するサービス（以下、「本サービス」といいます。）における、お客様の個人情報の取扱いについて、以下のとおりプライバシーポリシーを定めます。
+  </p>
+
+  <div class='mt-4'>
+    <h1 class='border-t border-blue-400 bg-blue-100 text-lg p-1'>お客様から取得する情報</h1>
+    <p class='mt-2'>当方は、お客様から以下の情報を取得します。</p>
+    <ul class='list-disc ml-10 mt-2'>
+      <li>氏名（ニックネームやペンネームも含む）</li>
+      <li>メールアドレス</li>
+      <li>Cookie（クッキー）を用いて生成された識別情報</li>
+    </ul>
+  </div>
+
+  <div class='mt-4'>
+    <h1 class='border-t border-blue-400 bg-blue-100 text-lg p-1'>お客様の情報を利用する目的</h1>
+    <p class='mt-2'>当方は、お客様から取得した情報を、以下の目的のために利用します。</p>
+    <ul class='list-disc ml-10 mt-2'>
+      <li>本サービスに関する登録の受付、お客様の本人確認、認証のため</li>
+      <li>お客様の本サービスの利用履歴を管理するため</li>
+      <li>当方の規約や法令に違反する行為に対応するため</li>
+      <li>本サービスの変更、提供中止、終了、契約解除をご連絡するため</li>
+      <li>当方規約の変更等を通知するため</li>
+      <li>以下の他、本サービスの提供、維持、保護及び改善のため</li>
+    </ul>
+  </div>
+
+  <div class='mt-4'>
+    <h1 class='border-t border-blue-400 bg-blue-100 text-lg p-1'>第三者提供</h1>
+    <p class='mt-2'>当方は、お客様から取得する情報のうち、個人データ（個人情報保護法第１６条第３項）に該当するものについては、あらかじめお客様からの同意を得ずに、第三者（日本国外にある者を含みます。）に提供しません。</p>
+    <p>但し、次の場合は除きます。</p>
+    <ul class='list-disc ml-10 mt-2'>
+      <li>個人データの取り扱いを外部に委託する場合</li>
+      <li>当方や本サービスが買収された場合</li>
+      <li>事業パートナーと共同利用する場合（具体的な共同利用がある場合は、その内容を別途公表します。）</li>
+    </ul>
+  </div>
+
+  <div class='mt-4'>
+    <h1 class='border-t border-blue-400 bg-blue-100 text-lg p-1'>プライバシーポリシーの変更</h1>
+    <p class='mt-2'>当方は、必要に応じて、このプライバシーポリシーの内容を変更します。この場合、変更後のプライバシーポリシーの施行時期と内容を適切な方法により周知または通知します。</p>
+  </div>
+
+  <div class='mt-4'>
+    <h1 class='border-t border-blue-400 bg-blue-100 text-lg p-1'>お問合せ</h1>
+    <p class='mt-2'>お客様の情報の開示、情報の訂正、利用停止、削除をご希望の方は、以下のメールアドレスにご連絡ください。</p>
+      <p>xxx.com</p>
+      <p>この場合、必ず、運転免許証のご提示等当方が指定する方法により、ご本人からのご請求であることの確認をさせていただきます。</p>
+  </div>
+
+  <div class='mt-4'>
+    <h1 class='border-t border-blue-400 bg-blue-100 text-lg p-1'>事業者の氏名</h1>
+    <p class='mt-2'>長田 雄</p>
+  </div>
+
+  <div class='mt-4 text-right'>
+    <p>最終改正 : 2023年12月19日 </p>
+  </div>
+
+
+
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "static_pages#top"
   get 'about_orceanize', to: 'static_pages#about_orceanize'
+  get 'privacy_policy', to: 'static_pages#privacy_policy'
 end


### PR DESCRIPTION
- ルーティング追記
```
get 'privacy_policy', to: 'static_pages#privacy_policy'
```

- footerに「プライバシーポリシーページ」へのリンク作成
- 「プライバシーポリシーページ」作成

ローカル環境での動作確認問題なし